### PR TITLE
pyopengl-accelerate 3.1.9

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+
+build_artefacts

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2017, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+About pyopengl-accelerate
+==============
+
+Home: https://mcfletch.github.io/pyopengl/
+
+Package license: LicenseRef-pyopengl
+
+Feedstock license: BSD 3-Clause
+
+Summary: This set of C (Cython) extensions provides acceleration of common operations for slow points in PyOpenGL 3.x. It is not a requirement for using PyOpenGL but performance without it will be poor.
+
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pyopengl/badges/version.svg)](https://anaconda.org/conda-forge/pyopengl)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pyopengl/badges/downloads.svg)](https://anaconda.org/conda-forge/pyopengl)
+
+Installing pyopengl-accelerate
+===================
+
+Installing `pyopengl-accelerate` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+
+```
+conda config --add channels conda-forge
+```
+
+Once the `conda-forge` channel has been enabled, `pyopengl-accelerate` can be installed with:
+
+```
+conda install pyopengl-accelerate
+```
+
+It is possible to list all of the versions of `pyopengl-accelerate` available on your platform with:
+
+```
+conda search pyopengl-accelerate
+```
+
+
+About conda-forge
+=================
+
+conda-forge is a community-led conda channel of installable packages.
+In order to provide high-quality builds, the process has been automated into the
+conda-forge GitHub organization. The conda-forge organization contains one repository
+for each of the installable packages. Such a repository is known as a *feedstock*.
+
+A feedstock is made up of a conda recipe (the instructions on what and how to build
+the package) and the necessary configurations for automatic building using freely
+available continuous integration services. Thanks to the awesome service provided by
+[CircleCI](https://circleci.com/), [AppVeyor](http://www.appveyor.com/)
+and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+packages to the [conda-forge](https://anaconda.org/conda-forge)
+[Anaconda-Cloud](http://docs.anaconda.org/) channel for Linux, Windows and OSX respectively.
+
+To manage the continuous integration and simplify feedstock maintenance
+[conda-smithy](http://github.com/conda-forge/conda-smithy) has been developed.
+Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
+this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
+
+
+Terminology
+===========
+
+**feedstock** - the conda recipe (raw material), supporting scripts and CI configuration.
+
+**conda-smithy** - the tool which helps orchestrate the feedstock.
+                   Its primary use is in the construction of the CI ``.yml`` files
+                   and simplify the management of *many* feedstocks.
+
+**conda-forge** - the place where the feedstock and smithy live and work to
+                  produce the finished article (built conda distributions)
+
+
+Updating pyopengl-accelerate-feedstock
+===========================
+
+If you would like to improve the pyopengl-accelerate recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/pyopengl-accelerate-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
+
+In order to produce a uniquely identifiable distribution:
+ * If the version of a package **is not** being increased, please add or increase
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
+ * If the version of a package **is** being increased, please remember to return
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
+   back to 0.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,18 @@
-{% set version = "3.1.5" %}
+{% set version = "3.1.9" %}
 
 package:
   name: pyopengl-accelerate
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/P/PyOpenGL-accelerate/PyOpenGL-accelerate-{{ version }}.tar.gz
-  sha256: 12e5518b0216a478527c7ce5ddce623c3d0517adeb87226da767772e8b7f2f06
+  url: https://pypi.io/packages/source/P/PyOpenGL-accelerate/pyopengl_accelerate-{{ version }}.tar.gz
+  sha256: 85957c7c76975818ff759ec9243f9dc7091ef6f373ea37a2eb50c320fd9a86f3
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+  # pyopengl isn't vailable on win.
+  skip: true  # [win]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
   build:
@@ -18,29 +20,34 @@ requirements:
   host:
     - python
     - pip
-    - cython
-    - numpy
+    - cython >=0.28
+    - numpy 2
+    - setuptools >=42.0
+    - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
-    - pyopengl
-    - freeglut        # [linux]
+    - numpy
+    - pyopengl  # [unix]
+    - freeglut  # [linux]
 
 test:
   imports:
     - OpenGL_accelerate
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http://pyopengl.sourceforge.net
-  license: BSD
+  home: https://mcfletch.github.io/pyopengl
+  license: LicenseRef-pyopengl
   license_file: license.txt
   license_family: BSD
   summary: Acceleration code for PyOpenGL
   description: |
     This set of C (Cython) extensions provides acceleration of common operations for slow points in PyOpenGL .
-  doc_url: http://pyopengl.sourceforge.net/documentation/index.html
-  doc_source_url: https://sourceforge.net/projects/pyopengl/
-  dev_url: https://github.com/mcfletch/pyopengl
+  doc_url: https://mcfletch.github.io/pyopengl/documentation/index.html
+  dev_url: https://github.com/mcfletch/pyopengl/tree/master/accelerate
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - python
     - numpy
     - pyopengl  # [unix]
-    - freeglut  # [linux]
+    - freeglut  # [linux and (not s390x)]
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7420](https://anaconda.atlassian.net/browse/PKG-7420) 
- [Upstream repository](https://github.com/mcfletch/pyopengl/tree/master/accelerate)
- pypi inspector: https://inspector.pypi.io/project/pyopengl-accelerate/3.1.9/packages/9d/9e/a87f972148971c785773dcc792226530ff78840420e34b3cc51b221693a2/pyopengl_accelerate-3.1.9.tar.gz/
- License: https://inspector.pypi.io/project/pyopengl-accelerate/3.1.9/packages/9d/9e/a87f972148971c785773dcc792226530ff78840420e34b3cc51b221693a2/pyopengl_accelerate-3.1.9.tar.gz/pyopengl_accelerate-3.1.9/license.txt
- Requirements:
  - https://inspector.pypi.io/project/pyopengl-accelerate/3.1.9/packages/9d/9e/a87f972148971c785773dcc792226530ff78840420e34b3cc51b221693a2/pyopengl_accelerate-3.1.9.tar.gz/pyopengl_accelerate-3.1.9/pyproject.toml
  - https://inspector.pypi.io/project/pyopengl-accelerate/3.1.9/packages/9d/9e/a87f972148971c785773dcc792226530ff78840420e34b3cc51b221693a2/pyopengl_accelerate-3.1.9.tar.gz/pyopengl_accelerate-3.1.9/setup.py

### Explanation of changes:

- Skip `win` because pyopengl repacks freeglut and GLE on Windows.

### Notes:

-

[PKG-7420]: https://anaconda.atlassian.net/browse/PKG-7420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ