### PR TITLE
pyopengl-accelerate 3.1.9 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
+channels:
+  - https://staging.continuum.io/prefect/fs/pyopengl-feedstock/pr5/15cb329

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/pyopengl-feedstock/pr5/15cb329

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 85957c7c76975818ff759ec9243f9dc7091ef6f373ea37a2eb50c320fd9a86f3
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip
     - cython >=0.28
     - numpy {{ numpy }}
+    - freeglut {{ freeglut }}  # [not osx]
     - setuptools >=42.0
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,16 @@
+{% set name = "pyopengl-accelerate" %}
 {% set version = "3.1.9" %}
 
 package:
-  name: pyopengl-accelerate
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/P/PyOpenGL-accelerate/pyopengl_accelerate-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/P/PyOpenGL-accelerate/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 85957c7c76975818ff759ec9243f9dc7091ef6f373ea37a2eb50c320fd9a86f3
 
 build:
   number: 0
-  # pyopengl isn't vailable on win.
-  skip: true  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
@@ -21,22 +20,27 @@ requirements:
     - python
     - pip
     - cython >=0.28
-    - numpy 2
+    - numpy {{ numpy }}
     - setuptools >=42.0
     - wheel
   run:
     - python
     - numpy
-    - pyopengl  # [unix]
-    - freeglut  # [linux and (not s390x)]
+    - pyopengl
+    - freeglut  # [not osx]
 
 test:
+  source_files:
+    - tests
   imports:
     - OpenGL_accelerate
-  requires:
-    - pip
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://mcfletch.github.io/pyopengl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   run:
     - python
     - numpy
-    - pyopengl
+    - pyopengl {{ version }}
     - freeglut  # [not osx]
 
 test:


### PR DESCRIPTION
pyopengl-accelerate 3.1.9 

**Destination channel:** Defaults

### Links

- [PKG-7962]
- dev_url:        https://github.com/mcfletch/pyopengl/tree/release-3.1.8
- conda_forge:    https://github.com/conda-forge/pyopengl-accelerate-feedstock
- pypi:           https://pypi.org/project/pyopengl-accelerate/3.1.9
- pypi inspector: https://inspector.pypi.io/project/pyopengl-accelerate/3.1.9

### Explanation of changes:

- new version number


[PKG-7962]: https://anaconda.atlassian.net/browse/PKG-7962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ